### PR TITLE
ci: scale Cloud Run services to zero when idle

### DIFF
--- a/.github/workflows/deploy_gradio_apps.yml
+++ b/.github/workflows/deploy_gradio_apps.yml
@@ -95,7 +95,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=judge,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -123,7 +123,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=ai-consequences,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -151,7 +151,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=what-is-ai,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -180,7 +180,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-en,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -208,7 +208,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-ca,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -236,7 +236,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-es,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -265,7 +265,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-en-final,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -293,7 +293,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-es-final,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -321,7 +321,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-ca-final,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -349,7 +349,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=ethical-revelation,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -377,7 +377,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=moral-compass-challenge,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -407,7 +407,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=bias-detective-en,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -435,7 +435,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=bias-detective-es,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -463,7 +463,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=bias-detective-ca,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -493,7 +493,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=fairness-fixer-en,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -521,7 +521,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=fairness-fixer-es,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -549,7 +549,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=fairness-fixer-ca,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -578,7 +578,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=justice-equity-upgrade-en,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -606,7 +606,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=justice-equity-upgrade-es,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -634,7 +634,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=justice-equity-upgrade-ca,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20

--- a/.github/workflows/deploy_gradio_apps_sustainability.yml
+++ b/.github/workflows/deploy_gradio_apps_sustainability.yml
@@ -112,7 +112,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-en-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -140,7 +140,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-ca-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -168,7 +168,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-es-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -197,7 +197,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-en-final-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -225,7 +225,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-es-final-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -253,7 +253,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=model-building-game-ca-final-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20,DEBUG_LOG=true
@@ -282,7 +282,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=bias-detective-en-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -310,7 +310,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=bias-detective-ca-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -338,7 +338,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=bias-detective-es-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -367,7 +367,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=fairness-fixer-en-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -395,7 +395,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=fairness-fixer-ca-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -423,7 +423,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=fairness-fixer-es-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -452,7 +452,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=sustainability-upgrade-en,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -480,7 +480,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=sustainability-upgrade-ca,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -508,7 +508,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=sustainability-upgrade-es,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -537,7 +537,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=moral-compass-en-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -565,7 +565,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=moral-compass-es-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20
@@ -593,7 +593,7 @@ jobs:
             --cpu=2
             --session-affinity
             --concurrency=20
-            --min-instances=1
+            --min-instances=0
             --max-instances=150
             --timeout=3000
             --set-env-vars=APP_NAME=moral-compass-ca-sustainability,GRADIO_SERVER_NAME=0.0.0.0,GRADIO_ANALYTICS_ENABLED=False,GRADIO_NUM_PORTS=1,GRADIO_DEFAULT_CONCURRENCY_LIMIT=20

--- a/.github/workflows/update_min_instances.yml
+++ b/.github/workflows/update_min_instances.yml
@@ -1,0 +1,169 @@
+name: Update min-instances on all services
+
+on:
+  workflow_dispatch:
+    inputs:
+      min_instances:
+        description: "Min instances to set (0 = scale to zero when idle)"
+        required: true
+        default: "0"
+      target:
+        description: "Which services to update"
+        required: true
+        type: choice
+        options:
+          - all
+          - sustainability-only
+          - standard-only
+      dry_run:
+        description: "Only report current min-instances; change nothing"
+        required: true
+        type: boolean
+        default: true
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: us-central1
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Update min-instances
+        run: |
+          set -euo pipefail
+          MIN="${{ inputs.min_instances }}"
+          DRY_RUN="${{ inputs.dry_run }}"
+
+          # Standard apps (deploy_gradio_apps.yml + deploy_single_apps.yml)
+          STANDARD_SERVICES=(
+            judge
+            ai-consequences
+            what-is-ai
+            tutorial
+            ethical-revelation
+            moral-compass-challenge
+            model-building-game
+            model-building-game-en
+            model-building-game-ca
+            model-building-game-es
+            model-building-game-en-final
+            model-building-game-es-final
+            model-building-game-ca-final
+            bias-detective-en
+            bias-detective-es
+            bias-detective-ca
+            fairness-fixer-en
+            fairness-fixer-es
+            fairness-fixer-ca
+            justice-equity-upgrade-en
+            justice-equity-upgrade-es
+            justice-equity-upgrade-ca
+          )
+
+          # Sustainability apps (deploy_gradio_apps_sustainability.yml)
+          SUSTAINABILITY_SERVICES=(
+            model-building-game-en-sustainability
+            model-building-game-ca-sustainability
+            model-building-game-es-sustainability
+            model-building-game-en-final-sustainability
+            model-building-game-es-final-sustainability
+            model-building-game-ca-final-sustainability
+            bias-detective-en-sustainability
+            bias-detective-ca-sustainability
+            bias-detective-es-sustainability
+            fairness-fixer-en-sustainability
+            fairness-fixer-ca-sustainability
+            fairness-fixer-es-sustainability
+            sustainability-upgrade-en
+            sustainability-upgrade-ca
+            sustainability-upgrade-es
+            moral-compass-en-sustainability
+            moral-compass-es-sustainability
+            moral-compass-ca-sustainability
+          )
+
+          TARGET="${{ inputs.target }}"
+          if [ "${TARGET}" = "sustainability-only" ]; then
+            SERVICES=("${SUSTAINABILITY_SERVICES[@]}")
+          elif [ "${TARGET}" = "standard-only" ]; then
+            SERVICES=("${STANDARD_SERVICES[@]}")
+          else
+            SERVICES=("${STANDARD_SERVICES[@]}" "${SUSTAINABILITY_SERVICES[@]}")
+          fi
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "DRY RUN: reporting current min-instances only, nothing will change."
+          fi
+          echo "Target: ${TARGET} (${#SERVICES[@]} services) -> min-instances=${MIN}"
+          echo ""
+
+          FAILED=()
+          UPDATED=0
+          SKIPPED=0
+
+          for SVC in "${SERVICES[@]}"; do
+            # Unset annotation means min-instances=0
+            CURRENT=$(gcloud run services describe "${SVC}" \
+              --region="${REGION}" \
+              --project="${PROJECT_ID}" \
+              --format="value(spec.template.metadata.annotations['autoscaling.knative.dev/minScale'])" \
+              2>/dev/null) || CURRENT="MISSING"
+            if [ "${CURRENT}" = "" ]; then
+              CURRENT=0
+            fi
+
+            if [ "${CURRENT}" = "MISSING" ]; then
+              echo "❌ ${SVC}: could not read current config (not deployed, or no access)"
+              FAILED+=("${SVC}")
+              continue
+            fi
+
+            if [ "${DRY_RUN}" = "true" ]; then
+              if [ "${CURRENT}" = "${MIN}" ]; then
+                echo "   ${SVC}: min-instances=${CURRENT} (already at target)"
+              else
+                echo "→  ${SVC}: min-instances=${CURRENT} would become ${MIN}"
+              fi
+              continue
+            fi
+
+            if [ "${CURRENT}" = "${MIN}" ]; then
+              echo "⏭️  ${SVC}: already min-instances=${MIN}, no new revision needed"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            echo "--- Updating ${SVC}: ${CURRENT} -> ${MIN} ---"
+            if gcloud run services update "${SVC}" \
+              --min-instances="${MIN}" \
+              --region="${REGION}" \
+              --project="${PROJECT_ID}" 2>&1; then
+              echo "✅ ${SVC} updated"
+              UPDATED=$((UPDATED + 1))
+            else
+              echo "❌ ${SVC} failed"
+              FAILED+=("${SVC}")
+            fi
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "Dry run over ${#SERVICES[@]} services; no changes made."
+          else
+            echo "Updated ${UPDATED}, already at target ${SKIPPED}, of ${#SERVICES[@]} services (min-instances=${MIN})"
+          fi
+          if [ ${#FAILED[@]} -gt 0 ]; then
+            echo "Failed: ${FAILED[*]}"
+            echo "Note: failures may be expected if some services are not deployed"
+            exit 1
+          fi


### PR DESCRIPTION
Sets every Cloud Run service to `min-instances=0` so nothing holds a warm instance while the apps are unused.

## What ran before this

Reconstructed from Actions history on this fork (March logs have expired, HTTP 410):

- `deploy_gradio_apps_sustainability.yml` — 44 runs Feb 10 → Mar 26. Last success `90a38635` (Mar 26 16:09) pinned all 18 sustainability services to `min-instances=1`.
- `update_sustainability_min_instances.yml` — one run ever (Mar 26 09:30), then **superseded 6.5h later** by the deploy above, which reset those 18 back to `1`.
- `deploy_gradio_apps.yml` — only run since Feb was cancelled; last success 2026-01-15, so its 20 services have carried a floor of `1` since January.
- `update_all_concurrency_limit.yml` / `update_what_is_ai_concurrency.yml` — env-var only, do not touch min-instances.
- `deploy-infra.yml` — pure Terraform; there is no `google_cloud_run` resource anywhere in the repo, so Terraform does not manage these services.

Best estimate of current live state: ~38 services at `min-instances=1`.

## Changes

**New `update_min_instances.yml`** — built on the `update_all_concurrency_limit.yml` structure, whose service lists ran successfully across all 39 services on Mar 26.

- `min_instances` defaults to `0` (the superseded workflow defaulted to `3`)
- `target`: `all` (40) / `sustainability-only` (18) / `standard-only` (22)
- `dry_run` defaults to **true** — reads each service's current `autoscaling.knative.dev/minScale` and reports what would change, without touching anything
- skips services already at target, avoiding pointless revision churn
- adds `model-building-game`, which was absent from the concurrency workflow's lists and would otherwise never be covered

Uses `gcloud run services update --min-instances`, a single-field change: same image, same memory/CPU/concurrency/env/timeout. Deliberately **not** the deploy workflows, which rebuild the image from HEAD and would ship five months of accumulated code as a side effect of a config tweak.

**Flipped 38 hardcoded lines** `--min-instances=1` → `=0`: 20 in `deploy_gradio_apps.yml`, 18 in `deploy_gradio_apps_sustainability.yml`. Without this, the next deploy silently restores the warm floor. Verified via `git diff -U0` that every changed line is a min-instances line.

## Verification

All three files parse as valid YAML. The script was smoke-tested against a stubbed `gcloud` across four cases: service at `1` (updates), unset/`0` (skipped, no new revision), `describe` fails (reported, no update attempted), `update` fails (reported, job exits 1).

Not yet run against live infrastructure — the plan is to dispatch with `dry_run: true` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)